### PR TITLE
[Part 1 of n] [SRP-23] Changes to clone action for leadership migration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,8 @@ venv/
 __pycache__/
 *.so
 *~
-
+.idea/
+.gitignore
 activate
 .tox
 .cache

--- a/kafka/tools/assigner/__main__.py
+++ b/kafka/tools/assigner/__main__.py
@@ -96,6 +96,7 @@ def is_dry_run(args):
 
 
 def main():
+
     # Start by loading all the modules
     action_map = get_module_map(kafka.tools.assigner.actions, kafka.tools.assigner.actions.ActionModule)
     sizer_map = get_module_map(kafka.tools.assigner.sizers, kafka.tools.assigner.sizers.SizerModule)
@@ -107,6 +108,8 @@ def main():
 
     tools_path = get_tools_path(args.tools_path)
     check_java_home()
+
+    time.sleep(args.pause)
 
     cluster = Cluster.create_from_zookeeper(args.zookeeper, getattr(args, 'default_retention', 1))
     run_plugins_at_step(plugins, 'set_cluster', cluster)

--- a/kafka/tools/assigner/__main__.py
+++ b/kafka/tools/assigner/__main__.py
@@ -57,7 +57,6 @@ def check_and_get_sizes(action_cls, args, cluster, sizer_map):
 
 def run_preferred_replica_elections(batches, args, tools_path, plugins, dry_run):
     for i, batch in enumerate(batches):
-        print(" inside run_preferred_replica_elections")
         # Sleep between PLEs
         if i > 0 and not dry_run:
             log.info("Waiting {0} seconds for replica election to complete".format(args.ple_wait))

--- a/kafka/tools/assigner/__main__.py
+++ b/kafka/tools/assigner/__main__.py
@@ -57,6 +57,7 @@ def check_and_get_sizes(action_cls, args, cluster, sizer_map):
 
 def run_preferred_replica_elections(batches, args, tools_path, plugins, dry_run):
     for i, batch in enumerate(batches):
+        print(" inside run_preferred_replica_elections")
         # Sleep between PLEs
         if i > 0 and not dry_run:
             log.info("Waiting {0} seconds for replica election to complete".format(args.ple_wait))
@@ -120,6 +121,7 @@ def main():
     newcluster = cluster.clone()
     action_to_run = action_map[args.action](args, newcluster)
     action_to_run.process_cluster()
+    time.sleep(args.pause)
     run_plugins_at_step(plugins, 'set_new_cluster', action_to_run.cluster)
     print_leadership("after", newcluster, args.leadership)
 
@@ -133,10 +135,12 @@ def main():
 
     for i, batch in enumerate(batches):
         log.info("Executing partition reassignment {0}/{1}: {2}".format(i + 1, len(batches), repr(batch)))
+        time.sleep(args.pause)
         batch.execute(i + 1, len(batches), args.zookeeper, tools_path, plugins, dry_run)
 
     run_plugins_at_step(plugins, 'before_ple')
 
+    time.sleep(args.pause)
     if not args.skip_ple:
         all_cluster_partitions = [p for p in action_to_run.cluster.partitions(args.exclude_topics)]
         batches = split_partitions_into_batches(all_cluster_partitions, batch_size=args.ple_size, use_class=ReplicaElection)

--- a/kafka/tools/assigner/actions/clone.py
+++ b/kafka/tools/assigner/actions/clone.py
@@ -29,9 +29,9 @@ class ActionClone(ActionModule):
         super(ActionClone, self).__init__(args, cluster)
 
         self.check_brokers()
-        # TODO Navneet - check how this was working in case of single target broker also
-        # if args.to_broker not in self.cluster.brokers:
-        #     raise ConfigurationException("Target broker is not in the brokers list for this cluster")
+        for to_broker in args.to_brokers:
+            if self.cluster.brokers[to_broker] is None:
+                raise ConfigurationException("Target broker is not in the brokers list for this cluster")
 
         self.topics = args.topics
         input_topics_not_present = []
@@ -48,13 +48,17 @@ class ActionClone(ActionModule):
 
     @classmethod
     def _add_args(cls, parser):
-        # in our case, we need to specify all LW brokers as we want to migrate leadership to AWS brokers,
-        # the processing is constrained by topics specified in args however
+
+        # we want to do partition leadership migration for specified topics only
+        parser.add_argument('-s', '--topics', help="List of topics's partition leaders to be migrated", required=True,
+                            type=str, nargs='*')
+
+        # for our requirement, we need to retire all LW brokers as we want to migrate leadership to AWS brokers,
+        # we can specify LW brokers here, no heavy duty processing as it'sconstrained by topics specified in args anyway
         parser.add_argument('-b', '--brokers', help="List of source brokers where leadership needs to be migrated from", required=True,
                             type=int, nargs='*')
-        # we want to do partition leadership migration for specified topics only
-        parser.add_argument('-s', '--topics', help="List of topics's partition leaders to be migrated", required=True, type=str, nargs='*')
-        # this is where cloning will happen, in our case this is expected to be broker in AWS
+
+        # this is the target brokers where cloning will happen, for our requirement, this is expected to be brokers in AWS
         parser.add_argument('-t', '--to_brokers', help="Broker ID to copy partitions to", required=True, type=int, nargs='*')
 
     def process_cluster(self):
@@ -65,10 +69,8 @@ class ActionClone(ActionModule):
         for partition in self.cluster.partitions_for(self.topics):
             if len(from_brokers & set([replica.id for replica in partition.replicas])) > 0:
                 to_broker = to_brokers.popleft()
-                print(" to_broker is " + str(to_broker))
                 to_brokers.append(to_broker)
                 targeted_broker = self.cluster.brokers[to_broker]
-                print(" targeted_broker is " + str(targeted_broker) + repr(targeted_broker))
                 if targeted_broker in partition.replicas:
                     log.warn("Targeted broker (ID {0}) is already in the replica list for {1}:{2}"
                              .format(targeted_broker.id, partition.topic.name, partition.num))

--- a/kafka/tools/assigner/actions/clone.py
+++ b/kafka/tools/assigner/actions/clone.py
@@ -31,27 +31,51 @@ class ActionClone(ActionModule):
         if args.to_broker not in self.cluster.brokers:
             raise ConfigurationException("Target broker is not in the brokers list for this cluster")
 
+        self.topics = args.topics
+        input_topics_not_present = []
+        for topic in self.topics:
+            if topic not in self.cluster.topics:
+                input_topics_not_present.append(topic)
+
+        if len(input_topics_not_present) > 0:
+            raise ConfigurationException("Target topic is not in the topic list for this cluster" + input_topics_not_present)
+
         self.sources = args.brokers
         self.to_broker = self.cluster.brokers[args.to_broker]
 
     @classmethod
     def _add_args(cls, parser):
-        parser.add_argument('-b', '--brokers', help="List of source broker IDs", required=True, type=int, nargs='*')
+        # in our case, we can specify all LW brokers as we want to migrate leadership to AWS brokers,
+        # the processing is limited by topics specified
+        parser.add_argument('-b', '--brokers', help="List of source brokers where leadership needs to be migrated from", required=True,
+                            type=int, nargs='*')
+        # we only want to do partition leadership migration topic by topic
+        parser.add_argument('-s', '--topics', help="List of topics's partition leaders to be migrated", required=True, type=str, nargs='*')
         parser.add_argument('-t', '--to_broker', help="Broker ID to copy partitions to", required=True, type=int)
 
     def process_cluster(self):
         source_set = set(self.sources)
-        for partition in self.cluster.partitions(self.args.exclude_topics):
+        print(" source_set is " + str(source_set))
+        for partition in self.cluster.partitions_for(self.topics):
+            print(" partition is " + str(partition.__dict__))
+            print(" partition replicas are " + str(partition.replicas))
+            print(" this should be printed")
             if len(source_set & set([replica.id for replica in partition.replicas])) > 0:
+                print(" check if to_broker " + str(self.to_broker) + " already a replica")
                 if self.to_broker in partition.replicas:
+                    print(" yes, " + str(self.to_broker) + " already a replica")
                     log.warn("Target broker (ID {0}) is already in the replica list for {1}:{2}".format(self.to_broker.id, partition.topic.name, partition.num))
-
                     # If the broker is already in the replica list, it ALWAYS becomes the leader
                     if self.to_broker != partition.replicas[0]:
                         partition.swap_replica_positions(self.to_broker, partition.replicas[0])
                 else:
-                    # If one of the source brokers is currently the leader, the target broker is the leader. Otherwise, the target leader is in second place
+                    print(" no, " + str(self.to_broker) + " not already a replica ")
+                    # If one of the source brokers is currently the leader, the target broker is the leader.
+                    # Otherwise, the target leader is in second place
+                    print(" check if source broker a leader for partition ")
                     if partition.replicas[0].id in self.sources:
+                        print(" source is leader, make to_broker  " + str(self.to_broker) + " leader of the partition")
                         partition.add_replica(self.to_broker, 0)
                     else:
+                        print(" source isn't leader, make to_broker  " + str(self.to_broker) + " second in replica list")
                         partition.add_replica(self.to_broker, 1)

--- a/kafka/tools/assigner/actions/setrf.py
+++ b/kafka/tools/assigner/actions/setrf.py
@@ -40,6 +40,7 @@ class ActionSetRF(ActionModule):
 
     def process_cluster(self):
         # Randomize a broker list to use for new replicas once. We'll round robin it from here
+        # Note - this can be modified to achieve more replicas in AWS specific brokers in our case, can change this to accept args
         idlist = list(self.cluster.brokers.keys())
         random.shuffle(idlist)
         brokers = deque(idlist)

--- a/kafka/tools/assigner/arguments.py
+++ b/kafka/tools/assigner/arguments.py
@@ -46,7 +46,7 @@ def set_up_arguments(action_map, sizer_map, plugins):
     aparser.add_argument('-l', '--leadership', help="Show cluster leadership balance", action='store_true')
     aparser.add_argument('-g', '--generate', help="Generate partition reassignment file", action='store_true')
     aparser.add_argument('-e', '--execute', help="Execute partition reassignment", action='store_true')
-    aparser.add_argument('-m', '--moves', help="Max number of moves per step", required=False, default=10, type=int)
+    aparser.add_argument('-m', '--moves', help="Max number of moves per step", required=False, default=1, type=int)
     aparser.add_argument('-x', '--exclude-topics', help="Comma-separated list of topics to skip when performing actions", action=CSVAction, default=[])
     aparser.add_argument('--sizer', help="Select module to use to get partition sizes", required=False, default='ssh', choices=sizer_map.keys())
     aparser.add_argument('-p', '--property', help="Property of the form 'key=value' to be passed to modules (i.e. sizer)", required=False, default=[],

--- a/kafka/tools/assigner/arguments.py
+++ b/kafka/tools/assigner/arguments.py
@@ -43,7 +43,7 @@ def set_up_arguments(action_map, sizer_map, plugins):
 
     aparser.add_argument('-v', '--version', action='version', version=str(pkg_resources.get_distribution("kafka-tools").version))
     aparser.add_argument('-z', '--zookeeper', help='Zookeeper path to the cluster (i.e. zk-eat1-kafka.corp:12913/kafka-data-deployment)', required=True)
-    aparser.add_argument('-l', '--leadership', help="Show cluster leadership balance", action='store_true')
+    aparser.add_argument('-l', '--leadership', help="Show cluster leadership balance", default=True, action='store_true')
     aparser.add_argument('-g', '--generate', help="Generate partition reassignment file", action='store_true')
     aparser.add_argument('-e', '--execute', help="Execute partition reassignment", action='store_true')
     aparser.add_argument('-m', '--moves', help="Max number of moves per step", required=False, default=1, type=int)
@@ -54,6 +54,7 @@ def set_up_arguments(action_map, sizer_map, plugins):
     aparser.add_argument('-s', '--size', help="Show partition sizes", action='store_true')
     aparser.add_argument('--skip-ple', help="Skip preferred replica election after finishing moves", action='store_true')
     aparser.add_argument('--ple-size', help="Max number of partitions in a single preferred leader election", required=False, default=2000, type=int)
+    aparser.add_argument('--pause', help="Time in seconds to pause between any two actions ", required=False, default=10, type=int)
     aparser.add_argument('--ple-wait', help="Time in seconds to wait between preferred leader elections", required=False, default=120, type=int)
     aparser.add_argument('--tools-path', help="Path to Kafka admin utilities, overriding PATH env var", required=False)
     aparser.add_argument('--output-json', help="Output JSON-formatted cluster information to stdout", default=False, action='store_true')

--- a/kafka/tools/assigner/arguments.py
+++ b/kafka/tools/assigner/arguments.py
@@ -54,7 +54,7 @@ def set_up_arguments(action_map, sizer_map, plugins):
     aparser.add_argument('-s', '--size', help="Show partition sizes", action='store_true')
     aparser.add_argument('--skip-ple', help="Skip preferred replica election after finishing moves", action='store_true')
     aparser.add_argument('--ple-size', help="Max number of partitions in a single preferred leader election", required=False, default=2000, type=int)
-    aparser.add_argument('--pause', help="Time in seconds to pause between any two actions ", required=False, default=10, type=int)
+    aparser.add_argument('--pause', help="Time in seconds to pause between any two actions, a default pause time of sorts", required=False, default=10, type=int)
     aparser.add_argument('--ple-wait', help="Time in seconds to wait between preferred leader elections", required=False, default=120, type=int)
     aparser.add_argument('--tools-path', help="Path to Kafka admin utilities, overriding PATH env var", required=False)
     aparser.add_argument('--output-json', help="Output JSON-formatted cluster information to stdout", default=False, action='store_true')

--- a/kafka/tools/assigner/models/reassignment.py
+++ b/kafka/tools/assigner/models/reassignment.py
@@ -63,7 +63,7 @@ class Reassignment(BaseModel):
                                     stdout=FNULL, stderr=FNULL)
             proc.wait()
             retries = 0
-            max_retries = 10
+            max_retries = 100
             # Wait until finished or max retries
             while retries < max_retries:
                 remaining_partitions = self.check_completion(zookeeper, tools_path, assignfile.name)

--- a/kafka/tools/assigner/models/reassignment.py
+++ b/kafka/tools/assigner/models/reassignment.py
@@ -62,9 +62,10 @@ class Reassignment(BaseModel):
                                      '--reassignment-json-file', assignfile.name],
                                     stdout=FNULL, stderr=FNULL)
             proc.wait()
-
-            # Wait until finished
-            while True:
+            retries = 0
+            max_retries = 10
+            # Wait until finished or max retries
+            while retries < max_retries:
                 remaining_partitions = self.check_completion(zookeeper, tools_path, assignfile.name)
                 if remaining_partitions == 0:
                     break
@@ -74,6 +75,7 @@ class Reassignment(BaseModel):
                                                                                                                                  remaining_partitions,
                                                                                                                                  len(self.partitions),
                                                                                                                                  self.pause_time))
+                retries += 1
                 time.sleep(self.pause_time)
 
     def process_verify_match(self, line):

--- a/kafka/tools/assigner/models/reassignment.py
+++ b/kafka/tools/assigner/models/reassignment.py
@@ -86,12 +86,16 @@ class Reassignment(BaseModel):
         return 0
 
     def check_completion(self, zookeeper, tools_path, assign_filename):
+
+        print("sleeping for {0} seconds before check completion ", str(self.pause_time))
+        time.sleep(self.pause_time)
         FNULL = open(os.devnull, 'w')
         proc = subprocess.Popen(['{0}/kafka-reassign-partitions.sh'.format(tools_path), '--verify',
                                  '--zookeeper', zookeeper,
                                  '--reassignment-json-file', assign_filename],
                                 stdout=subprocess.PIPE, stderr=FNULL)
         lines = proc.stdout.readlines()
+        print("lines in proc out " + str(lines))
 
         remaining_count = 0
         for line in lines:

--- a/kafka/tools/assigner/models/reassignment.py
+++ b/kafka/tools/assigner/models/reassignment.py
@@ -87,7 +87,6 @@ class Reassignment(BaseModel):
 
     def check_completion(self, zookeeper, tools_path, assign_filename):
 
-        print("sleeping for {0} seconds before check completion ", str(self.pause_time))
         time.sleep(self.pause_time)
         FNULL = open(os.devnull, 'w')
         proc = subprocess.Popen(['{0}/kafka-reassign-partitions.sh'.format(tools_path), '--verify',
@@ -95,7 +94,6 @@ class Reassignment(BaseModel):
                                  '--reassignment-json-file', assign_filename],
                                 stdout=subprocess.PIPE, stderr=FNULL)
         lines = proc.stdout.readlines()
-        print("lines in proc out " + str(lines))
 
         remaining_count = 0
         for line in lines:

--- a/kafka/tools/assigner/models/replica_election.py
+++ b/kafka/tools/assigner/models/replica_election.py
@@ -41,7 +41,8 @@ class ReplicaElection(BaseModel):
 
     def execute(self, num, total, zookeeper, tools_path, plugins=[], dry_run=True):
         if not dry_run:
-            with NamedTemporaryFile(mode='w') as assignfile:
+            with NamedTemporaryFile(mode='w', delete=False) as assignfile:
+                # print(repr(assignfile.__dict__))
                 json.dump(self.dict_for_replica_election(), assignfile)
                 assignfile.flush()
                 FNULL = open(os.devnull, 'w')
@@ -49,3 +50,4 @@ class ReplicaElection(BaseModel):
                                  '--zookeeper', zookeeper,
                                  '--path-to-json-file', assignfile.name],
                                 stdout=FNULL, stderr=FNULL)
+

--- a/kafka/tools/assigner/models/replica_election.py
+++ b/kafka/tools/assigner/models/replica_election.py
@@ -41,8 +41,7 @@ class ReplicaElection(BaseModel):
 
     def execute(self, num, total, zookeeper, tools_path, plugins=[], dry_run=True):
         if not dry_run:
-            with NamedTemporaryFile(mode='w', delete=False) as assignfile:
-                # print(repr(assignfile.__dict__))
+            with NamedTemporaryFile(mode='w') as assignfile:
                 json.dump(self.dict_for_replica_election(), assignfile)
                 assignfile.flush()
                 FNULL = open(os.devnull, 'w')
@@ -50,4 +49,3 @@ class ReplicaElection(BaseModel):
                                  '--zookeeper', zookeeper,
                                  '--path-to-json-file', assignfile.name],
                                 stdout=FNULL, stderr=FNULL)
-

--- a/kafka/tools/models/cluster.py
+++ b/kafka/tools/models/cluster.py
@@ -142,6 +142,7 @@ class Cluster(BaseModel):
             for partition in self.topics[topic].partitions:
                 yield partition
 
+    # NOTE - need to change this method to accept source brokers also and return partitions where only source brokers are leaders
     def partitions_for(self, include_topics=[]):
         partitions = []
         for topic in include_topics:

--- a/kafka/tools/models/cluster.py
+++ b/kafka/tools/models/cluster.py
@@ -142,6 +142,15 @@ class Cluster(BaseModel):
             for partition in self.topics[topic].partitions:
                 yield partition
 
+    def partitions_for(self, include_topics=[]):
+        partitions = []
+        for topic in include_topics:
+            log.debug("Including topic {0}".format(topic))
+            for partition in self.topics[topic].partitions:
+                partitions.append(partition)
+
+        return partitions
+
     def num_brokers(self):
         return len(self.brokers)
 

--- a/kafka/tools/models/partition.py
+++ b/kafka/tools/models/partition.py
@@ -15,22 +15,26 @@
 # specific language governing permissions and limitations
 # under the License.
 
+
 from __future__ import division
 
 from kafka.tools.exceptions import ReplicaNotFoundException
 from kafka.tools.models import BaseModel
 
+import time
+
 
 class Partition(BaseModel):
     equality_attrs = ['topic', 'num']
 
-    def __init__(self, topic, num):
+    def __init__(self, topic, num, pause_time=10):
         self.topic = topic
         self.num = num
         self.leader = None
         self.replicas = []
         self.size = 0
         self.scaled_size = 0
+        self.pause_time = pause_time
 
     # Shallow copy - do not copy replica list (zero length)
     def copy(self):
@@ -110,6 +114,8 @@ class Partition(BaseModel):
         self.remove_replica(remove_broker)
         self.add_replica(add_broker, position)
 
+        time.sleep(self.pause_time)
+
     # Given two brokers that appear in the replica list, swap their positions (making sure to adjust the broker objects as well)
     # If either replica is not in the list, throw an exception
     def swap_replica_positions(self, broker1, broker2):
@@ -130,6 +136,10 @@ class Partition(BaseModel):
         # Last, swap the replica positons on this partition object
         self.replicas[p1] = broker2
         self.replicas[p2] = broker1
+
+        time.sleep(self.pause_time)
+
+
 
     # Helper function to add a partition to a broker
     # This should never be called - please use the add_replica method

--- a/kafka/tools/models/partition.py
+++ b/kafka/tools/models/partition.py
@@ -15,7 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-
 from __future__ import division
 
 from kafka.tools.exceptions import ReplicaNotFoundException

--- a/setup.py
+++ b/setup.py
@@ -105,16 +105,16 @@ setup(
     # Versions should comply with PEP440.  For a discussion on single-sourcing
     # the version across setup.py and the project code, see
     # https://packaging.python.org/en/latest/single_source_version.html
-    version='0.1.9',
+    version='0.1.9.1',
 
-    author='Todd Palino',
-    author_email='tpalino@linkedin.com',
+    author='Platform Engineering',
+    author_email='platform-engineering@transferwise.com',
 
     description='A collection of tools and scripts for working with Apache Kafka',
     long_description=long_description,
 
     # The project's main homepage.
-    url='https://github.com/linkedin/kafka-tools',
+    url='https://github.com/transferwise/kafka-tools',
 
     # Choose your license
     license='Apache 2.0',


### PR DESCRIPTION
The PR includes the following

Changes in clone action. The clone action can increase replication factor (or not). The clone action changes leadership if previous leader was in the list of source_brokers.
Added the ability in clone action to migrate to multiple target brokers based on round-robin fashion
Added the ability to restrict the migration on a topic by topic basis.
Added enough sleep times to ensure there's no overlap of executions, this is conservative, can reduce/remove this in few places later
Added some comments as notes on some changes that can be done separately( perhaps in next PR )